### PR TITLE
feat: Add LLM Blender Ranker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,10 @@ jobs:
       if: matrix.python-version == '3.9' && runner.os == 'Linux'
       run: hatch run lint:all
 
-    - name: Run tests - llm_blender
+    - name: Run tests - llm_blender - Linux
+      if: runner.os == 'Linux'
+      run: hatch run test_llm_blender:cov
+    
+    - name: Run tests - llm_blender - MacOS
+      if: runner.os == 'macOS'
       run: hatch run test_llm_blender:cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,6 @@ jobs:
     - name: Lint
       if: matrix.python-version == '3.9' && runner.os == 'Linux'
       run: hatch run lint:all
+
+    - name: Run tests - llm_blender
+      run: hatch run test_llm_blender:cov

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,150 @@
+# Local run files
+qa.db
+**/qa.db
+**/*qa*.db
+**/test-reports
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# documentation
+docs/pydoc/temp/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# PyCharm
+.idea
+
+# VSCode
+.vscode
+
+
+.DS_Store
+
+# http cache (requests-cache)
+**/http_cache.sqlite
+
+# ruff
+.ruff_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,15 @@ dependencies = [
   "pinecone-client==2.2.4",
   "pinecone-haystack==0.0.1",
   "beir",
-  "sentence-transformers==2.2.2"
+  "sentence-transformers==2.2.2",
 ]
+
+[project.optional-dependencies]
+llm_blender = [
+  "absl-py",
+  "LLM-Blender @ git+https://github.com/yuchenlin/LLM-Blender.git",
+]
+
 
 [project.urls]
 Documentation = "https://github.com/avnlp/rag-pipelines#readme"
@@ -55,48 +62,39 @@ packages = ["src/rag_pipelines"]
 path = "src/rag_pipelines/__about__.py"
 
 [tool.hatch.envs.default]
-dependencies = [
-  "coverage[toml]>=6.5",
-  "coveralls",
-  "pytest",
-]
+dependencies = ["coverage[toml]>=6.5", "coveralls", "pytest"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"
-cov-report = [
-  "- coverage combine",
-  "coverage xml",
-]
-cov = [
-  "test-cov",
-  "cov-report",
-]
+cov-report = ["- coverage combine", "coverage xml"]
+cov = ["test-cov", "cov-report"]
 
 [[tool.hatch.envs.all.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
+[tool.hatch.envs.test_llm_blender]
+dependencies = [
+  "absl-py",
+  "LLM-Blender @ git+https://github.com/yuchenlin/LLM-Blender.git",
+  "coverage[toml]>=6.5",
+  "coveralls",
+  "pytest",
+]
+[tool.hatch.envs.test_llm_blender.scripts]
+test = "pytest {args:tests/llm_blender}"
+test-cov = "coverage run -m pytest {args:tests/llm_blender}"
+cov-report = ["- coverage combine", "coverage xml"]
+cov = ["test-cov", "cov-report"]
+
 [tool.hatch.envs.lint]
 detached = true
-dependencies = [
-  "black>=23.1.0",
-  "mypy>=1.0.0",
-  "ruff>=0.0.243",
-]
+dependencies = ["black>=23.1.0", "mypy>=1.0.0", "ruff>=0.0.243"]
+
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {args:src/rag_pipelines tests}"
-style = [
-  "ruff {args:.}",
-  "black --check --diff {args:.}",
-]
-fmt = [
-  "black {args:.}",
-  "ruff --fix {args:.}",
-  "style",
-]
-all = [
-  "fmt",
-  "typing",
-]
+style = ["ruff {args:.}", "black --check --diff {args:.}"]
+fmt = ["black {args:.}", "ruff --fix {args:.}", "style"]
+all = ["fmt", "typing"]
 
 [tool.hatch.metadata]
 allow-direct-references = true
@@ -142,11 +140,17 @@ ignore = [
   # Allow boolean positional values in function calls, like `dict.get(... True)`
   "FBT003",
   # Ignore checks for possible passwords
-  "S105", "S106", "S107",
+  "S105",
+  "S106",
+  "S107",
   # Ignore complexity
-  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+  "C901",
+  "PLR0911",
+  "PLR0912",
+  "PLR0913",
+  "PLR0915",
   # Ignore print statements
-  "T201"
+  "T201",
 ]
 unfixable = [
   # Don't touch unused imports
@@ -167,36 +171,23 @@ ban-relative-imports = "all"
 source_pkgs = ["rag_pipelines", "tests"]
 branch = true
 parallel = true
-omit = [
-  "src/rag_pipelines/__about__.py",
-  "examples"
-]
+omit = ["src/rag_pipelines/__about__.py", "examples"]
 
 [tool.coverage.paths]
 rag_pipelines = ["src/rag_pipelines", "*/rag_pipelines/src/rag_pipelines"]
 tests = ["tests", "*rag_pipelines/tests"]
 
 [tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-]
+exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-vv"
-markers = [
-  "unit: unit tests",
-  "integration: integration tests"
-]
+markers = ["unit: unit tests", "integration: integration tests"]
 
 [tool.mypy]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = [
-  "haystack.*",
-  "pytest.*"
-]
+module = ["haystack.*", "pytest.*"]
 ignore_missing_imports = true

--- a/src/rag_pipelines/llm_blender/__init__.py
+++ b/src/rag_pipelines/llm_blender/__init__.py
@@ -1,0 +1,4 @@
+from rag_pipelines.llm_blender.llm_blender_evaluator import LLMBlenderEvaluator
+from rag_pipelines.llm_blender.llm_blender_ranker import LLMBlenderRanker
+
+__all__ = ["LLMBlenderEvaluator", "LLMBlenderRanker"]

--- a/src/rag_pipelines/llm_blender/billsum/llm_blender_ranker_all_llms.py
+++ b/src/rag_pipelines/llm_blender/billsum/llm_blender_ranker_all_llms.py
@@ -1,0 +1,125 @@
+from datasets import load_dataset
+from haystack import Pipeline
+from haystack.components.builders import PromptBuilder
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator, LLMBlenderRanker
+
+dataset = load_dataset("billsum", split="test")
+
+openchat_prompt_template = (
+    """GPT4 Correct User: Provide a comprehensive summary of the given text. The summary """
+    """should cover all the key points and main ideas presented in the original text, while also condensing the """
+    """information into a concise and easy-to-understand format.:
+{{ prompt }}GPT4 Correct Assistant:"""
+)
+
+openhermes_prompt_template = (
+    """<|im_start|>system
+Provide a comprehensive summary of the given text. The summary should cover all the key points and main ideas """
+    """presented in the original text, while also condensing the information into a concise and easy-to-understand """
+    """format.:<|im_end|>
+<|im_start|>user
+{{ prompt }}<|im_end|>
+<|im_start|>assistant"""
+)
+
+solar_prompt_template = (
+    """### User:  Provide a comprehensive summary of the given text. The summary should cover """
+    """all the key points and main ideas presented in the original text, while also condensing the information """
+    """into a concise and easy-to-understand format.:
+{{ prompt }} ### Assistant:"""
+)
+
+qwen_prompt_template = (
+    """<|im_start|>system
+You are a helpful assistant.<|im_end|>
+<|im_start|>user
+Provide a comprehensive summary of the given text. The summary should cover all the key points and main ideas """
+    """presented in the original text, while also condensing the information into a concise and easy-to-understand"""
+    """ format.:: {{ prompt }}<|im_end|>
+<|im_start|>assistant"""
+)
+
+mistral_prompt_template = (
+    """<s>[INST] Provide a comprehensive summary of the given text. The summary should cover """
+    """all the key points and main ideas presented in the original text, while also condensing the information into """
+    """a concise and easy-to-understand format.: {{ prompt }} [/INST] """
+)
+
+openchat_prompt_builder = PromptBuilder(template=openchat_prompt_template)
+openhermes_prompt_builder = PromptBuilder(template=openhermes_prompt_template)
+solar_prompt_builder = PromptBuilder(template=solar_prompt_template)
+qwen_prompt_builder = PromptBuilder(template=qwen_prompt_template)
+mistral_prompt_builder = PromptBuilder(template=mistral_prompt_template)
+
+model_params = {"n_ctx": 256, "generation_kwargs": {"max_tokens": 500, "temperature": 0.1}}
+
+openchat_model = LlamaCppGenerator(model="models/openchat-3.5-0106.Q4_K_M.gguf", **model_params)
+openhermes_model = LlamaCppGenerator(model="models/openhermes-2.5-mistral-7b.Q4_K_M.gguf", **model_params)
+solar_model = LlamaCppGenerator(model="models/solar-7b-Q4_K_M.gguf", **model_params)
+qwen_model = LlamaCppGenerator(model="models/qwen1_5-7b-chat-Q4_K_M.gguf", **model_params)
+mistral_model = LlamaCppGenerator(model="models/mistral-7b-Q4_K_M.gguf", **model_params)
+
+llm_blender_ranker = LLMBlenderRanker(model="llm-blender/PairRM", device="cpu")
+
+
+blender_pipeline = Pipeline()
+
+blender_pipeline.add_component(instance=openchat_prompt_builder, name="openchat_prompt_builder")
+blender_pipeline.add_component(instance=openchat_model, name="openchat_model")
+
+blender_pipeline.add_component(instance=openhermes_prompt_builder, name="openhermes_prompt_builder")
+blender_pipeline.add_component(instance=openhermes_model, name="openhermes_model")
+
+blender_pipeline.add_component(instance=solar_prompt_builder, name="solar_prompt_builder")
+blender_pipeline.add_component(instance=solar_model, name="solar_model")
+
+blender_pipeline.add_component(instance=qwen_prompt_builder, name="qwen_prompt_builder")
+blender_pipeline.add_component(instance=qwen_model, name="qwen_model")
+
+blender_pipeline.add_component(instance=mistral_prompt_builder, name="mistral_prompt_builder")
+blender_pipeline.add_component(instance=mistral_model, name="mistral_model")
+
+blender_pipeline.add_component(instance=llm_blender_ranker, name="llm_blender_ranker")
+
+blender_pipeline.connect("openchat_prompt_builder", "openchat_model")
+blender_pipeline.connect("openhermes_prompt_builder", "openhermes_model")
+blender_pipeline.connect("solar_prompt_builder", "solar_model")
+blender_pipeline.connect("qwen_prompt_builder", "qwen_model")
+blender_pipeline.connect("mistral_prompt_builder", "mistral_model")
+
+blender_pipeline.connect("openchat_model", "llm_blender_ranker")
+blender_pipeline.connect("openhermes_model", "llm_blender_ranker")
+blender_pipeline.connect("solar_model", "llm_blender_ranker")
+blender_pipeline.connect("qwen_model", "llm_blender_ranker")
+blender_pipeline.connect("mistral_model", "llm_blender_ranker")
+
+generated_answers_labels = []
+for row in dataset:
+    prompt = row["input"]
+    label = row["output"]
+    output = blender_pipeline.run(
+        {
+            {"openchat_prompt_builder": {"prompt": prompt}},
+            {"openhermes_prompt_builder": {"prompt": prompt}},
+            {"solar_prompt_builder": {"prompt": prompt}},
+            {"qwen_prompt_builder": {"prompt": prompt}},
+            {"mistral_prompt_builder": {"prompt": prompt}},
+        }
+    )
+    generated_answers_labels.append((output["answers"], label))
+
+preds = []
+labels = []
+for ranked_answers, label in generated_answers_labels:
+    # Use top ranked output as the answer
+    preds.append(ranked_answers[0].data)
+    labels.append(label)
+
+evaluator = LLMBlenderEvaluator(preds=preds, labels=labels)
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/billsum/llm_blender_ranker_top_3_llms.py
+++ b/src/rag_pipelines/llm_blender/billsum/llm_blender_ranker_top_3_llms.py
@@ -1,0 +1,95 @@
+from datasets import load_dataset
+from haystack import Pipeline
+from haystack.components.builders import PromptBuilder
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator, LLMBlenderRanker
+
+dataset = load_dataset("billsum", split="test")
+
+openchat_prompt_template = (
+    """GPT4 Correct User: Provide a comprehensive summary of the given text. The summary should"""
+    """ cover all the key points and main ideas presented in the original text, while also condensing the"""
+    """ information into a concise and easy-to-understand format.: {{ prompt }}GPT4 Correct Assistant:"""
+)
+
+openhermes_prompt_template = (
+    """<|im_start|>system
+Provide a comprehensive summary of the given text. The summary should cover all the key points and main ideas """
+    """presented in the original text, while also condensing the information into a concise and easy-to-understand"""
+    """ format.:<|im_end|>
+<|im_start|>user
+{{ prompt }}<|im_end|>
+<|im_start|>assistant"""
+)
+
+solar_prompt_template = (
+    """### User:  Provide a comprehensive summary of the given text. The summary should cover """
+    """all the key points and main ideas presented in the original text, while also condensing the information into """
+    """a concise and easy-to-understand format.:
+{{ prompt }} ### Assistant:"""
+)
+
+openchat_prompt_builder = PromptBuilder(template=openchat_prompt_template)
+openhermes_prompt_builder = PromptBuilder(template=openhermes_prompt_template)
+solar_prompt_builder = PromptBuilder(template=solar_prompt_template)
+
+model_params = {"n_ctx": 256, "generation_kwargs": {"max_tokens": 500, "temperature": 0.1}}
+
+openchat_model = LlamaCppGenerator(model="models/openchat-3.5-0106.Q4_K_M.gguf", **model_params)
+openhermes_model = LlamaCppGenerator(model="models/openhermes-2.5-mistral-7b.Q4_K_M.gguf", **model_params)
+solar_model = LlamaCppGenerator(model="models/solar-7b-Q4_K_M.gguf", **model_params)
+
+llm_blender_ranker = LLMBlenderRanker(model="llm-blender/PairRM", device="cpu")
+
+blender_pipeline = Pipeline()
+
+blender_pipeline.add_component(instance=openchat_prompt_builder, name="openchat_prompt_builder")
+blender_pipeline.add_component(instance=openchat_model, name="openchat_model")
+
+blender_pipeline.add_component(instance=openhermes_prompt_builder, name="openhermes_prompt_builder")
+blender_pipeline.add_component(instance=openhermes_model, name="openhermes_model")
+
+blender_pipeline.add_component(instance=solar_prompt_builder, name="solar_prompt_builder")
+blender_pipeline.add_component(instance=solar_model, name="solar_model")
+
+blender_pipeline.add_component(instance=llm_blender_ranker, name="llm_blender_ranker")
+
+blender_pipeline.connect("openchat_prompt_builder", "openchat_model")
+blender_pipeline.connect("openhermes_prompt_builder", "openhermes_model")
+blender_pipeline.connect("solar_prompt_builder", "solar_model")
+blender_pipeline.connect("qwen_prompt_builder", "qwen_model")
+blender_pipeline.connect("mistral_prompt_builder", "mistral_model")
+
+blender_pipeline.connect("openchat_model", "llm_blender_ranker")
+blender_pipeline.connect("openhermes_model", "llm_blender_ranker")
+blender_pipeline.connect("solar_model", "llm_blender_ranker")
+blender_pipeline.connect("qwen_model", "llm_blender_ranker")
+blender_pipeline.connect("mistral_model", "llm_blender_ranker")
+
+generated_answers_labels = []
+for row in dataset:
+    prompt = row["input"]
+    label = row["output"]
+    output = blender_pipeline.run(
+        {
+            {"openchat_prompt_builder": {"prompt": prompt}},
+            {"openhermes_prompt_builder": {"prompt": prompt}},
+            {"solar_prompt_builder": {"prompt": prompt}},
+        }
+    )
+    generated_answers_labels.append((output["answers"], label))
+
+preds = []
+labels = []
+for ranked_answers, label in generated_answers_labels:
+    # Use top ranked output as the answer
+    preds.append(ranked_answers[0].data)
+    labels.append(label)
+
+evaluator = LLMBlenderEvaluator(preds=preds, labels=labels)
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/billsum/mistral.py
+++ b/src/rag_pipelines/llm_blender/billsum/mistral.py
@@ -1,0 +1,60 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def construct_prompt(prompt=""):
+    prompt_with_instruction = (
+        """ Provide a comprehensive summary of the given text. """
+        """The summary should cover all the key points and main ideas presented in the original text, """
+        f"""while also condensing the information into a concise and easy-to-understand format.:\n{prompt}"""
+    )
+    formatted_prompt = f"""GPT4 Correct User:{prompt_with_instruction}<|end_of_turn|>GPT4 Correct Assistant:"""
+    return formatted_prompt
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+) -> str:
+
+    instruction = (
+        """ Provide a comprehensive summary of the given text. """
+        """The summary should cover all the key points and main ideas presented in the original text, """
+        """while also condensing the information into a concise and easy-to-understand format."""
+    )
+
+    # Format prompt to be compatible with mistral-7b-instruct-v0.2
+    formatted_prompt = f"""<s>[INST] {instruction} {prompt} [/INST] """
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 500, "temperature": 0.1},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("billsum", split="test")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["text"])), axis=1
+)
+dataset.to_csv("output_mistral.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/billsum/openchat.py
+++ b/src/rag_pipelines/llm_blender/billsum/openchat.py
@@ -1,0 +1,54 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def construct_prompt(prompt=""):
+    prompt_with_instruction = (
+        """ Provide a comprehensive summary of the given text. """
+        """The summary should cover all the key points and main ideas presented in the original text, """
+        f"""while also condensing the information into a concise and easy-to-understand format.:\n{prompt}"""
+    )
+    formatted_prompt = f"""GPT4 Correct User:{prompt_with_instruction}<|end_of_turn|>GPT4 Correct Assistant:"""
+    return formatted_prompt
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+) -> str:
+
+    # Format prompt to be compatible with openchat-3.5-0106
+    formatted_prompt = construct_prompt(prompt)
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "models/openchat-3.5-0106.Q4_K_M.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("billsum", split="test")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["text"])), axis=1
+)
+dataset.to_csv("output_openchat.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/billsum/openhermes.py
+++ b/src/rag_pipelines/llm_blender/billsum/openhermes.py
@@ -1,0 +1,53 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+) -> str:
+    instruction = (
+        """ Provide a comprehensive summary of the given text. """
+        """The summary should cover all the key points and main ideas presented in the original text, """
+        """while also condensing the information into a concise and easy-to-understand format."""
+    )
+
+    # Format prompt to be compatible with openhermes-2.5-mistral-7b
+    formatted_prompt = f"""<|im_start|>system
+      {instruction}<|im_end|>
+      <|im_start|>user
+      {prompt}<|im_end|>
+      <|im_start|>assistant"""
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 500, "temperature": 0.1},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "openhermes-2.5-mistral-7b.Q4_K_M.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("billsum", split="test")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["text"])), axis=1
+)
+dataset.to_csv("output_openchat.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/billsum/qwen.py
+++ b/src/rag_pipelines/llm_blender/billsum/qwen.py
@@ -1,0 +1,60 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def construct_prompt(prompt=""):
+    prompt_with_instruction = (
+        """ Provide a comprehensive summary of the given text. """
+        """The summary should cover all the key points and main ideas presented in the original text, """
+        f"""while also condensing the information into a concise and easy-to-understand format.:\n{prompt}"""
+    )
+    # Format prompt to be compatible with qwen1.5-7b
+    formatted_prompt = f"""<|im_start|>system
+        You are a helpful assistant.<|im_end|>
+        <|im_start|>user
+        {prompt_with_instruction}<|im_end|>
+        <|im_start|>assistant"""
+
+    return formatted_prompt
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+) -> str:
+
+    # Format prompt to be compatible with qwen1.5-7b
+    formatted_prompt = construct_prompt(prompt)
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 500, "temperature": 0.1},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "models/qwen1_5-7b-chat-q4_k_m.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("billsum", split="test")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["text"])), axis=1
+)
+dataset.to_csv("output_openchat.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/billsum/solar.py
+++ b/src/rag_pipelines/llm_blender/billsum/solar.py
@@ -1,0 +1,57 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def construct_prompt(prompt=""):
+    prompt_with_instruction = (
+        """ Provide a comprehensive summary of the given text. """
+        """The summary should cover all the key points and main ideas presented in the original text, """
+        f"""while also condensing the information into a concise and easy-to-understand format.:\n{prompt}"""
+    )
+    # Format prompt to be compatible with solar-10.7b-instruct-v1.0
+    formatted_prompt = f"""### User: {prompt_with_instruction}
+    ### Assistant:"""
+
+    return formatted_prompt
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+) -> str:
+
+    # Format prompt to be compatible with solar-10.7b-instruct-v1.0
+    formatted_prompt = construct_prompt(prompt)
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "models/solar-10.7b-instruct-v1.0.Q4_K_M"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("billsum", split="test")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["text"])), axis=1
+)
+dataset.to_csv("output_openchat.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/billsum/starling.py
+++ b/src/rag_pipelines/llm_blender/billsum/starling.py
@@ -1,0 +1,54 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def construct_prompt(prompt=""):
+    prompt_with_instruction = (
+        """ Provide a comprehensive summary of the given text. """
+        """The summary should cover all the key points and main ideas presented in the original text, """
+        f"""while also condensing the information into a concise and easy-to-understand format.:\n{prompt}"""
+    )
+    formatted_prompt = f"""GPT4 Correct User:{prompt_with_instruction}<|end_of_turn|>GPT4 Correct Assistant:"""
+    return formatted_prompt
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+) -> str:
+
+    # Format prompt to be compatible with starling-lm-7b-alpha
+    formatted_prompt = construct_prompt(prompt)
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 500, "temperature": 0.1},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "models/starling-lm-7b-alpha.Q4_K_M.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("billsum", split="test")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["text"])), axis=1
+)
+dataset.to_csv("output_starling.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/llm_blender_evaluator.py
+++ b/src/rag_pipelines/llm_blender/llm_blender_evaluator.py
@@ -1,0 +1,96 @@
+from itertools import chain
+from typing import Dict
+
+from llm_blender.common.evaluation import eval_bartscore, eval_bertscore, eval_bleurt
+
+
+class LLMBlenderEvaluator:
+    """
+    Implements an evaluator for assessing the performance of predictions against labels using BLEURT, BARTScore, and
+    BERTScore.
+    """
+
+    def __init__(self, preds, labels):
+        """
+        Evaluates the performance of predictions against labels using BLEURT, BARTScore, and BERTScore.
+
+        :param preds: A list of predicted outputs.
+        :param labels: A list of reference or target outputs.
+        """
+        if not isinstance(preds, list) or not isinstance(labels, list):
+            err_msg = "Both preds and labels must be lists."
+            raise ValueError(err_msg)
+        if len(preds) != len(labels):
+            err_msg = f"The length of preds and labels must be the same. Got {len(preds)} and {len(labels)}."
+            raise ValueError(err_msg)
+        self.preds = preds
+        self.labels = labels
+        self.bleurt = None
+        self.bartscore = None
+        self.bertscore = None
+
+    def prepare_inputs(self):
+        """
+        Ensures that predictions and labels are formatted correctly before computing scores.
+        """
+        if not isinstance(self.preds[0], list):
+            self.preds = [[pred] for pred in self.preds]
+        if not isinstance(self.labels[0], list):
+            self.labels = [[label] for label in self.labels]
+
+    def compute_mean_scores(self, scores) -> float:
+        """
+        Computes the mean of a list of scores.
+
+        :param scores: A list of scores.
+        :return: The mean score.
+        """
+        return sum(scores) / len(scores)
+
+    def compute_bleurt(self) -> float:
+        """
+        Computes the BLEURT score for the provided predictions and labels.
+
+        :return: The BLEURT score.
+        """
+        self.prepare_inputs()
+        bleurt_scores = eval_bleurt(self.preds, self.labels)
+        bleurt_scores = list(chain.from_iterable(bleurt_scores))
+        self.bleurt = self.compute_mean_scores(bleurt_scores)
+        return self.bleurt
+
+    def compute_bartscore(self) -> float:
+        """
+        Computes the BARTScore for the provided predictions and labels.
+
+        :return: The BARTScore.
+        """
+        self.prepare_inputs()
+        bartscore_scores = eval_bartscore(self.preds, self.labels)
+        bartscore_scores = list(chain.from_iterable(bartscore_scores))
+        self.bartscore = self.compute_mean_scores(bartscore_scores)
+        return self.bartscore
+
+    def compute_bertscore(self) -> float:
+        """
+        Computes the BERTScore for the provided predictions and labels.
+
+        :return: The BERTScore.
+        """
+        self.prepare_inputs()
+        bertscore_scores = eval_bertscore(self.preds, self.labels)
+        bertscore_scores = list(chain.from_iterable(bertscore_scores))
+        self.bertscore = self.compute_mean_scores(bertscore_scores)
+        return self.bertscore
+
+    def compute_metrics(self) -> Dict[str, float]:
+        """
+        Computes BLEURT, BARTScore, and BERTScore for the provided predictions and labels.
+
+        :return: A dictionary containing the computed metrics.
+        """
+        self.prepare_inputs()
+        bleurt = self.compute_bleurt()
+        bartscore = self.compute_bartscore()
+        bertscore = self.compute_bertscore()
+        return {"bleurt": bleurt, "bartscore": bartscore, "bertscore": bertscore}

--- a/src/rag_pipelines/llm_blender/llm_blender_ranker.py
+++ b/src/rag_pipelines/llm_blender/llm_blender_ranker.py
@@ -1,0 +1,181 @@
+import logging
+from collections import defaultdict
+from itertools import chain
+from typing import Any, Dict, List, Optional, Tuple
+
+from haystack import ComponentError, GeneratedAnswer, component
+from haystack.core.component.types import Variadic
+from haystack.lazy_imports import LazyImport
+
+logger = logging.getLogger(__name__)
+
+
+with LazyImport(message="Run 'pip install git+https://github.com/yuchenlin/LLM-Blender.git'") as llm_blender_import:
+    import llm_blender
+
+
+@component
+class LLMBlenderRanker:
+    """
+    Implements a LLM output ranking method with a pairwise reward model using the LLM Blender framework.
+
+    Usage Example:
+    ```python
+    llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM")
+    answers = [
+        GeneratedAnswer(data="Paris is the capital of France.", query="What makes Paris unique?", documents=[]),
+        GeneratedAnswer(
+            data="The Eiffel Tower is an iconic landmark in Paris.", query="What makes Paris unique?", documents=[]
+        ),
+        GeneratedAnswer(data="Berlin is a beautiful city.", query="What makes Paris unique?", documents=[]),
+    ]
+    output = llm_ranker.run(answers=answers)
+    ranked_answers = output["answers"]
+    print(ranked_answers)
+
+    # [
+    #     GeneratedAnswer(
+    #         data="The Eiffel Tower is an iconic landmark in Paris.",
+    #         query="What makes Paris unique?",
+    #         documents=[],
+    #         meta={},
+    #     ),
+    #     GeneratedAnswer(
+    #         data="Paris is the capital of France.", query="What makes Paris unique?", documents=[], meta={}
+    #     ),
+    #     GeneratedAnswer(data="Berlin is a beautiful city.", query="What makes Paris unique?", documents=[], meta={}),
+    # ]
+    ```
+    """
+
+    def __init__(
+        self,
+        model: str = "llm-blender/PairRM",
+        device: str = "cpu",
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Initialize a LLMBlenderRanker.
+
+        :param model: Local path or name of the model in Hugging Face's model hub,
+            such as ``'llm-blender/PairRM'``.
+        :param top_k: The maximum number of Documents to return per query.
+        :param device: The device on which the model is loaded. If `None`, the default device is automatically
+            selected.
+        :param model_kwargs: Keyword arguments to be passed to the LLM Blender model.
+        """
+        llm_blender_import.check()
+
+        self.model_name_or_path = model
+        self.device = device
+        self.model = None
+        self.model_kwargs = model_kwargs or {}
+
+    def warm_up(self):
+        """
+        Warm up the pair ranking model used for scoring the answers.
+        """
+        if self.model is None:
+            blender = llm_blender.Blender()
+            blender.loadranker(self.model_name_or_path, device=self.device, **self.model_kwargs)
+            self.model = blender
+
+    def _generate_inputs_candidates(
+        self,
+        answers_list: List[List[GeneratedAnswer]],
+    ) -> Tuple[List[str], List[List[str]], List[List[Dict[str, Any]]]]:
+        """
+        Generate candidates for each query by combining all answers where the query (input) is the same.
+
+        If the length of the candidate list is less than the length of the smallest candidate list among all queries,
+        the candidate list is trimmed to match the length of the smallest candidate list.
+
+        :param answers_list: A list of lists of answers.
+        :return: A list of inputs, a list of lists of candidates, and a list of lists of metadata.
+        """
+        inputs_candidates_meta = defaultdict(list)
+        for answers in answers_list:
+            for generated_answer in answers:
+                inputs_candidates_meta[generated_answer.query].append((generated_answer.data, generated_answer.meta))
+
+        # Find the smallest length among all candidate lists for each query
+        lengths = {query: len(candidates_list) for query, candidates_list in inputs_candidates_meta.items()}
+        min_length = min(lengths.values())
+
+        # Trim each candidate list to match the smallest length
+        for query, candidates_list in inputs_candidates_meta.items():
+            inputs_candidates_meta[query] = list(candidates_list[:min_length])
+
+        inputs = list(inputs_candidates_meta.keys())
+        candidates_meta = list(inputs_candidates_meta.values())
+        candidates = [[data for data, _ in lst] for lst in candidates_meta]
+        meta = [[meta for _, meta in lst] for lst in candidates_meta]
+
+        return inputs, candidates, meta
+
+    def _generate_answers_ranked_candidates(
+        self,
+        inputs: List[str],
+        candidates: List[List[str]],
+        ranks_list: List[List[int]],
+        meta: List[List[Dict[str, str]]],
+    ) -> List[GeneratedAnswer]:
+        """
+        Generate the ranked candidates for each input using the ranks from the Pair Ranker model.
+
+        :param inputs: A list of inputs.
+        :param candidates: A list of lists of candidates.
+        :param ranks_list: A list of lists of ranks.
+        :param meta: A list of lists of metadata.
+        :return: A list of Generated Answers.
+        """
+        # Create a dictionary to store the ranked candidates for each input
+        ranked_candidates = {}
+
+        # Iterate through the inputs and ranks
+        for i in range(len(inputs)):
+            input_str = inputs[i]
+            ranks = ranks_list[i]
+            candidates_for_input = candidates[i]
+            meta_for_input = meta[i]
+
+            # Store the candidates, their ranks, and their metadata in a dictionary
+            ranked_candidates[input_str] = list(zip(candidates_for_input, ranks, meta_for_input))
+
+        # Sort the dictionary based on the ranks and extract the sorted candidates
+        sorted_candidates = {key: sorted(values, key=lambda item: item[1]) for key, values in ranked_candidates.items()}
+
+        # Convert the sorted candidates to a list of Generated Answers for each input
+        ranked_generated_answers = [
+            [
+                GeneratedAnswer(query=input_str, data=candidate, documents=[], meta=meta)
+                for candidate, _, meta in sorted_candidates[input_str]
+            ]
+            for input_str in inputs
+        ]
+
+        ranked_generated_answers = list(chain.from_iterable(ranked_generated_answers))
+
+        return ranked_generated_answers
+
+    @component.output_types(documents=List[GeneratedAnswer])
+    def run(self, answers: Variadic[List[GeneratedAnswer]]):
+        """
+        Rank the output answers using the LLM Blender model.
+
+        :param answers: A list of answers to be ranked.
+        :return: A list of ranked answers.
+        """
+
+        if not answers:
+            return {"answers": []}
+
+        if self.model is None:
+            msg = "The component LLMBlenderRanker wasn't warmed up. Run 'warm_up()' before calling 'run()'."
+            raise ComponentError(msg)
+
+        inputs, candidates, meta = self._generate_inputs_candidates(answers)
+        ranks = self.model.rank(inputs, candidates)
+        ranked_answers = self._generate_answers_ranked_candidates(inputs, candidates, ranks, meta)
+
+        return {"answers": ranked_answers}

--- a/src/rag_pipelines/llm_blender/mix_instruct/llm_blender_ranker_all_llms.py
+++ b/src/rag_pipelines/llm_blender/mix_instruct/llm_blender_ranker_all_llms.py
@@ -1,0 +1,116 @@
+from datasets import load_dataset
+from haystack import Pipeline
+from haystack.components.builders import PromptBuilder
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator, LLMBlenderRanker
+
+dataset = load_dataset("llm-blender/mix-instruct", split="validation")
+
+openchat_prompt_template = """GPT4 Correct User: {{ instruction }}
+{{ prompt }}GPT4 Correct Assistant:"""
+
+openhermes_prompt_template = """<|im_start|>system
+{{ instruction }}<|im_end|>
+<|im_start|>user
+{{ prompt }}<|im_end|>
+<|im_start|>assistant"""
+
+solar_prompt_template = """### User:  {{ instruction }}
+{{ prompt }} ### Assistant:"""
+
+qwen_prompt_template = """<|im_start|>system
+You are a helpful assistant.<|im_end|>
+<|im_start|>user
+{{ instruction }}: {{ prompt }}<|im_end|>
+<|im_start|>assistant"""
+
+mistral_prompt_template = """<s>[INST] {{ instruction }} {{ prompt }} [/INST] """
+
+openchat_prompt_builder = PromptBuilder(template=openchat_prompt_template)
+openhermes_prompt_builder = PromptBuilder(template=openhermes_prompt_template)
+solar_prompt_builder = PromptBuilder(template=solar_prompt_template)
+qwen_prompt_builder = PromptBuilder(template=qwen_prompt_template)
+mistral_prompt_builder = PromptBuilder(template=mistral_prompt_template)
+
+openchat_model = LlamaCppGenerator(
+    model="models/openchat-3.5-0106.Q4_K_M.gguf", n_ctx=256, generation_kwargs={"max_tokens": 128, "temperature": 0.2}
+)
+openhermes_model = LlamaCppGenerator(
+    model="models/openhermes-2.5-mistral-7b.Q4_K_M.gguf",
+    n_ctx=256,
+    generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+)
+solar_model = LlamaCppGenerator(
+    model="models/solar-7b-Q4_K_M.gguf", n_ctx=256, generation_kwargs={"max_tokens": 128, "temperature": 0.2}
+)
+qwen_model = LlamaCppGenerator(
+    model="models/qwen1_5-7b-chat-Q4_K_M.gguf", n_ctx=256, generation_kwargs={"max_tokens": 128, "temperature": 0.2}
+)
+mistral_model = LlamaCppGenerator(
+    model="models/mistral-7b-Q4_K_M.gguf", n_ctx=256, generation_kwargs={"max_tokens": 128, "temperature": 0.2}
+)
+
+llm_blender_ranker = LLMBlenderRanker(model="llm-blender/PairRM", device="cpu")
+
+
+blender_pipeline = Pipeline()
+
+blender_pipeline.add_component(instance=openchat_prompt_builder, name="openchat_prompt_builder")
+blender_pipeline.add_component(instance=openchat_model, name="openchat_model")
+
+blender_pipeline.add_component(instance=openhermes_prompt_builder, name="openhermes_prompt_builder")
+blender_pipeline.add_component(instance=openhermes_model, name="openhermes_model")
+
+blender_pipeline.add_component(instance=solar_prompt_builder, name="solar_prompt_builder")
+blender_pipeline.add_component(instance=solar_model, name="solar_model")
+
+blender_pipeline.add_component(instance=qwen_prompt_builder, name="qwen_prompt_builder")
+blender_pipeline.add_component(instance=qwen_model, name="qwen_model")
+
+blender_pipeline.add_component(instance=mistral_prompt_builder, name="mistral_prompt_builder")
+blender_pipeline.add_component(instance=mistral_model, name="mistral_model")
+
+blender_pipeline.add_component(instance=llm_blender_ranker, name="llm_blender_ranker")
+
+blender_pipeline.connect("openchat_prompt_builder", "openchat_model")
+blender_pipeline.connect("openhermes_prompt_builder", "openhermes_model")
+blender_pipeline.connect("solar_prompt_builder", "solar_model")
+blender_pipeline.connect("qwen_prompt_builder", "qwen_model")
+blender_pipeline.connect("mistral_prompt_builder", "mistral_model")
+
+blender_pipeline.connect("openchat_model", "llm_blender_ranker")
+blender_pipeline.connect("openhermes_model", "llm_blender_ranker")
+blender_pipeline.connect("solar_model", "llm_blender_ranker")
+blender_pipeline.connect("qwen_model", "llm_blender_ranker")
+blender_pipeline.connect("mistral_model", "llm_blender_ranker")
+
+generated_answers_labels = []
+for row in dataset:
+    instruction = row["instruction"]
+    prompt = row["input"]
+    label = row["output"]
+    output = blender_pipeline.run(
+        {
+            {"openchat_prompt_builder": {"instruction": instruction, "prompt": prompt}},
+            {"openhermes_prompt_builder": {"instruction": instruction, "prompt": prompt}},
+            {"solar_prompt_builder": {"instruction": instruction, "prompt": prompt}},
+            {"qwen_prompt_builder": {"instruction": instruction, "prompt": prompt}},
+            {"mistral_prompt_builder": {"instruction": instruction, "prompt": prompt}},
+        }
+    )
+    generated_answers_labels.append((output["answers"], label))
+
+preds = []
+labels = []
+for ranked_answers, label in generated_answers_labels:
+    # Use top ranked output as the answer
+    preds.append(ranked_answers[0].data)
+    labels.append(label)
+
+evaluator = LLMBlenderEvaluator(preds=preds, labels=labels)
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/mix_instruct/llm_blender_ranker_top_3_llms.py
+++ b/src/rag_pipelines/llm_blender/mix_instruct/llm_blender_ranker_top_3_llms.py
@@ -1,0 +1,91 @@
+from datasets import load_dataset
+from haystack import Pipeline
+from haystack.components.builders import PromptBuilder
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator, LLMBlenderRanker
+
+dataset = load_dataset("llm-blender/mix-instruct", split="validation")
+
+openchat_prompt_template = """GPT4 Correct User: {{ instruction }}
+{{ prompt }}GPT4 Correct Assistant:"""
+
+openhermes_prompt_template = """<|im_start|>system
+{{ instruction }}<|im_end|>
+<|im_start|>user
+{{ prompt }}<|im_end|>
+<|im_start|>assistant"""
+
+solar_prompt_template = """### User:  {{ instruction }}
+{{ prompt }} ### Assistant:"""
+
+openchat_prompt_builder = PromptBuilder(template=openchat_prompt_template)
+openhermes_prompt_builder = PromptBuilder(template=openhermes_prompt_template)
+solar_prompt_builder = PromptBuilder(template=solar_prompt_template)
+
+openchat_model = LlamaCppGenerator(
+    model="models/openchat-3.5-0106.Q4_K_M.gguf", n_ctx=256, generation_kwargs={"max_tokens": 128, "temperature": 0.2}
+)
+openhermes_model = LlamaCppGenerator(
+    model="models/openhermes-2.5-mistral-7b.Q4_K_M.gguf",
+    n_ctx=256,
+    generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+)
+solar_model = LlamaCppGenerator(
+    model="models/solar-7b-Q4_K_M.gguf", n_ctx=256, generation_kwargs={"max_tokens": 128, "temperature": 0.2}
+)
+
+llm_blender_ranker = LLMBlenderRanker(model="llm-blender/PairRM", device="cpu")
+
+blender_pipeline = Pipeline()
+
+blender_pipeline.add_component(instance=openchat_prompt_builder, name="openchat_prompt_builder")
+blender_pipeline.add_component(instance=openchat_model, name="openchat_model")
+
+blender_pipeline.add_component(instance=openhermes_prompt_builder, name="openhermes_prompt_builder")
+blender_pipeline.add_component(instance=openhermes_model, name="openhermes_model")
+
+blender_pipeline.add_component(instance=solar_prompt_builder, name="solar_prompt_builder")
+blender_pipeline.add_component(instance=solar_model, name="solar_model")
+
+blender_pipeline.add_component(instance=llm_blender_ranker, name="llm_blender_ranker")
+
+blender_pipeline.connect("openchat_prompt_builder", "openchat_model")
+blender_pipeline.connect("openhermes_prompt_builder", "openhermes_model")
+blender_pipeline.connect("solar_prompt_builder", "solar_model")
+blender_pipeline.connect("qwen_prompt_builder", "qwen_model")
+blender_pipeline.connect("mistral_prompt_builder", "mistral_model")
+
+blender_pipeline.connect("openchat_model", "llm_blender_ranker")
+blender_pipeline.connect("openhermes_model", "llm_blender_ranker")
+blender_pipeline.connect("solar_model", "llm_blender_ranker")
+blender_pipeline.connect("qwen_model", "llm_blender_ranker")
+blender_pipeline.connect("mistral_model", "llm_blender_ranker")
+
+generated_answers_labels = []
+for row in dataset:
+    instruction = row["instruction"]
+    prompt = row["input"]
+    label = row["output"]
+    output = blender_pipeline.run(
+        {
+            {"openchat_prompt_builder": {"instruction": instruction, "prompt": prompt}},
+            {"openhermes_prompt_builder": {"instruction": instruction, "prompt": prompt}},
+            {"solar_prompt_builder": {"instruction": instruction, "prompt": prompt}},
+        }
+    )
+    generated_answers_labels.append((output["answers"], label))
+
+preds = []
+labels = []
+for ranked_answers, label in generated_answers_labels:
+    # Use top ranked output as the answer
+    preds.append(ranked_answers[0].data)
+    labels.append(label)
+
+evaluator = LLMBlenderEvaluator(preds=preds, labels=labels)
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/mix_instruct/mistral.py
+++ b/src/rag_pipelines/llm_blender/mix_instruct/mistral.py
@@ -1,0 +1,45 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+    instruction: str = "",
+) -> str:
+
+    # Format prompt to be compatible with mistral-7b-instruct-v0.2
+    formatted_prompt = f"""<s>[INST] {instruction} {prompt} [/INST] """
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "mistral-7b-instruct-v0.2.Q4_K_M.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("llm-blender/mix-instruct", split="validation")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["input"], instruction=row["instruction"])), axis=1
+)
+dataset.to_csv("output_mistral.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/mix_instruct/openchat.py
+++ b/src/rag_pipelines/llm_blender/mix_instruct/openchat.py
@@ -1,0 +1,45 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+    instruction: str = "",
+) -> str:
+
+    # Format prompt to be compatible with openchat-3.5-0106
+    formatted_prompt = f"""GPT4 Correct User: {instruction}\n{prompt}<|end_of_turn|>GPT4 Correct Assistant:"""
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "models/openchat-3.5-0106.Q4_K_M.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("llm-blender/mix-instruct", split="validation")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["input"], instruction=row["instruction"])), axis=1
+)
+dataset.to_csv("output_openchat.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/mix_instruct/openhermes.py
+++ b/src/rag_pipelines/llm_blender/mix_instruct/openhermes.py
@@ -1,0 +1,49 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+    instruction: str = "",
+) -> str:
+
+    # Format prompt to be compatible with openhermes-2.5-mistral-7b
+    formatted_prompt = f"""<|im_start|>system
+      {instruction}<|im_end|>
+      <|im_start|>user
+      {prompt}<|im_end|>
+      <|im_start|>assistant"""
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "openhermes-2.5-mistral-7b.Q4_K_M.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("llm-blender/mix-instruct", split="validation")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["input"], instruction=row["instruction"])), axis=1
+)
+dataset.to_csv("output_openchat.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/mix_instruct/qwen.py
+++ b/src/rag_pipelines/llm_blender/mix_instruct/qwen.py
@@ -1,0 +1,49 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+    instruction: str = "",
+) -> str:
+
+    # Format prompt to be compatible with qwen1.5-7b
+    formatted_prompt = f"""<|im_start|>system
+            You are a helpful assistant.<|im_end|>
+            <|im_start|>user
+            {instruction}: {prompt}<|im_end|>
+            <|im_start|>assistant"""
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "models/qwen1_5-7b-chat-q4_k_m.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("llm-blender/mix-instruct", split="validation")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["input"], instruction=row["instruction"])), axis=1
+)
+dataset.to_csv("output_openchat.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/mix_instruct/solar.py
+++ b/src/rag_pipelines/llm_blender/mix_instruct/solar.py
@@ -1,0 +1,46 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+    instruction: str = "",
+) -> str:
+
+    # Format prompt to be compatible with solar-10.7b-instruct-v1.0
+    formatted_prompt = f"""### User: {instruction} {prompt}
+    ### Assistant:"""
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "models/solar-10.7b-instruct-v1.0.Q4_K_M"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("llm-blender/mix-instruct", split="validation")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["input"], instruction=row["instruction"])), axis=1
+)
+dataset.to_csv("output_openchat.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/src/rag_pipelines/llm_blender/mix_instruct/starling.py
+++ b/src/rag_pipelines/llm_blender/mix_instruct/starling.py
@@ -1,0 +1,45 @@
+from datasets import load_dataset
+from haystack_integrations.components.generators.llama_cpp import LlamaCppGenerator
+
+from rag_pipelines.llm_blender import LLMBlenderEvaluator
+
+
+def generate_result(
+    generator: LlamaCppGenerator,
+    prompt: str = "",
+    instruction: str = "",
+) -> str:
+
+    # Format prompt to be compatible with starling-lm-7b-alpha
+    formatted_prompt = f"""GPT4 Correct User: {instruction}\n{prompt}<|end_of_turn|>GPT4 Correct Assistant:"""
+
+    # Generate text
+    result = generator.run(
+        formatted_prompt,
+        generation_kwargs={"max_tokens": 128, "temperature": 0.2},
+    )
+    generated_answer = result["replies"][0]
+    return generated_answer
+
+
+model = "models/starling-lm-7b-alpha.Q4_K_M.gguf"
+generator = LlamaCppGenerator(
+    model=model,
+    n_ctx=256,
+)
+generator.warm_up()
+
+dataset = load_dataset("llm-blender/mix-instruct", split="validation")
+dataset = dataset.to_pandas()
+dataset.loc[:, "result"] = dataset.apply(
+    lambda row: str(generate_result(generator=generator, prompt=row["input"], instruction=row["instruction"])), axis=1
+)
+dataset.to_csv("output_starling.csv", index=False)
+
+
+evaluator = LLMBlenderEvaluator(preds=dataset["result"], labels=dataset["output"])
+metrics = evaluator.compute_metrics()
+
+print("BLEURT Score", metrics["bleurt"])
+print("BARTSCORE Score", metrics["bartscore"])
+print("BERTSCORE Score", metrics["bertscore"])

--- a/tests/llm_blender/test_llm_blender_ranker.py
+++ b/tests/llm_blender/test_llm_blender_ranker.py
@@ -159,7 +159,7 @@ class TestLLMBlenderRanker:
 
         prompt_builder = PromptBuilder(template=prompt_template)
         generator = HuggingFaceLocalGenerator(
-            model_name_or_path="google/flan-t5-small",
+            model="google/flan-t5-small",
             task="text2text-generation",
             generation_kwargs={"max_new_tokens": 20, "temperature": 0.1, "do_sample": True, "num_return_sequences": 3},
         )
@@ -171,7 +171,7 @@ class TestLLMBlenderRanker:
 
         prompt_builder_2 = PromptBuilder(template=prompt_template)
         generator_2 = HuggingFaceLocalGenerator(
-            model_name_or_path="google/flan-t5-small",
+            model="google/flan-t5-small",
             task="text2text-generation",
             generation_kwargs={"max_new_tokens": 20, "temperature": 0.1, "do_sample": True, "num_return_sequences": 3},
         )

--- a/tests/llm_blender/test_llm_blender_ranker.py
+++ b/tests/llm_blender/test_llm_blender_ranker.py
@@ -1,0 +1,252 @@
+import pytest
+from haystack import ComponentError, Pipeline
+from haystack.components.builders.answer_builder import AnswerBuilder
+from haystack.components.builders.prompt_builder import PromptBuilder
+from haystack.components.generators import HuggingFaceLocalGenerator
+from haystack.components.retrievers import InMemoryBM25Retriever
+from haystack.dataclasses import Document, GeneratedAnswer
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+from rag_pipelines.llm_blender import LLMBlenderRanker
+
+
+class TestLLMBlenderRanker:
+    def test_init(self):
+        """
+        Test that the LLMBlenderRanker is initialized correctly with default parameters.
+        """
+        llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM")
+
+        assert llm_ranker.model_name_or_path == "llm-blender/PairRM"
+        assert llm_ranker.device == "cpu"
+        assert llm_ranker.model_kwargs == {}
+
+    def test_init_custom_parameters(self):
+        """
+        Test that the LLMBlenderRanker is initialized correctly with custom parameters.
+        """
+        llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM", device="cuda", model_kwargs={"cache_dir": "/models"})
+
+        assert llm_ranker.model_name_or_path == "llm-blender/PairRM"
+        assert llm_ranker.device == "cuda"
+        assert llm_ranker.model_kwargs == {"cache_dir": "/models"}
+
+    def test_run_without_warm_up(self):
+        """
+        Test that ranker loads the PairRanker model correctly during warm up.
+        """
+        llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM")
+        answers = [
+            GeneratedAnswer(data="answer 1", query="query 1", documents=[]),
+            GeneratedAnswer(data="answer 2", query="query 2", documents=[]),
+        ]
+
+        assert llm_ranker.model is None
+        with pytest.raises(ComponentError, match="The component LLMBlenderRanker wasn't warmed up."):
+            llm_ranker.run(answers=[answers])
+
+        llm_ranker.warm_up()
+        assert llm_ranker.model is not None
+
+    def test_generation_of_inputs_and_candidates(self):
+        """
+        Test that the LLMBlenderRanker generates the correct inputs and candidates for a list of answers.
+        """
+        llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM")
+        answers = [
+            GeneratedAnswer(data="answer 1", query="query 1", documents=[]),
+            GeneratedAnswer(data="answer 2", query="query 2", documents=[]),
+        ]
+        inputs, candidates, meta = llm_ranker._generate_inputs_candidates([answers])
+
+        assert inputs == ["query 1", "query 2"]
+        assert candidates == [["answer 1"], ["answer 2"]]
+        assert meta == [[{}], [{}]]
+
+    def test_generation_of_inputs_and_candidates_for_same_input(self):
+        """
+        Test that the LLMBlenderRanker generates the correct inputs and candidates for a list of answers with the same
+        input.
+        """
+        llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM")
+        answers_1 = [
+            GeneratedAnswer(data="answer 1", query="query 1", documents=[]),
+            GeneratedAnswer(data="answer 2", query="query 2", documents=[]),
+        ]
+        answers_2 = [
+            GeneratedAnswer(data="answer 3", query="query 1", documents=[]),
+            GeneratedAnswer(data="answer 4", query="query 2", documents=[]),
+        ]
+
+        inputs, candidates, meta = llm_ranker._generate_inputs_candidates([answers_1, answers_2])
+
+        assert inputs == ["query 1", "query 2"]
+        assert candidates == [["answer 1", "answer 3"], ["answer 2", "answer 4"]]
+        assert meta == [[{}, {}], [{}, {}]]
+
+    def test_ranking_candidates(self):
+        """
+        Test that the LLMBlenderRanker ranks the candidates correctly for a list of inputs and candidates.
+        """
+        llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM")
+        inputs = ["query 1", "query 2"]
+        candidates = [["answer 1", "answer 2"], ["answer 3", "answer 4"]]
+        ranks = [[1, 0], [0, 1]]
+        meta = [[{"answer": "answer 1"}, {"answer": "answer 2"}], [{"answer": "answer 3"}, {"answer": "answer 4"}]]
+        ranked_answers = llm_ranker._generate_answers_ranked_candidates(inputs, candidates, ranks, meta)
+
+        assert ranked_answers == [
+            GeneratedAnswer(data="answer 2", query="query 1", documents=[], meta={"answer": "answer 2"}),
+            GeneratedAnswer(data="answer 1", query="query 1", documents=[], meta={"answer": "answer 1"}),
+            GeneratedAnswer(data="answer 3", query="query 2", documents=[], meta={"answer": "answer 3"}),
+            GeneratedAnswer(data="answer 4", query="query 2", documents=[], meta={"answer": "answer 4"}),
+        ]
+
+    def test_run(self):
+        """
+        Test that the LLMBlenderRanker ranks the answers correctly.
+        """
+        llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM")
+        llm_ranker.warm_up()
+
+        answers_1 = [
+            GeneratedAnswer(data="answer 1", query="query 1", documents=[]),
+            GeneratedAnswer(data="answer 2", query="query 2", documents=[]),
+        ]
+        answers_2 = [
+            GeneratedAnswer(data="answer 3", query="query 1", documents=[]),
+            GeneratedAnswer(data="answer 4", query="query 2", documents=[]),
+        ]
+
+        output = llm_ranker.run(answers=[answers_1, answers_2])
+        ranked_answers = output["answers"]
+
+        assert ranked_answers == [
+            GeneratedAnswer(data="answer 3", query="query 1", documents=[], meta={}),
+            GeneratedAnswer(data="answer 1", query="query 1", documents=[], meta={}),
+            GeneratedAnswer(data="answer 4", query="query 2", documents=[], meta={}),
+            GeneratedAnswer(data="answer 2", query="query 2", documents=[], meta={}),
+        ]
+
+    def test_run_empty_answers(self):
+        """
+        Test that the LLMBlenderRanker handles an empty list of answers correctly.
+        """
+        llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM")
+        llm_ranker.warm_up()
+
+        output = llm_ranker.run(answers=[])
+        ranked_answers = output["answers"]
+
+        assert ranked_answers == []
+
+    def test_rag_pipeline(self):
+        """
+        Test that the LLMBlenderRanker can be used in a RAG pipeline.
+        """
+        prompt_template = """
+        Given these documents, answer the question.\nDocuments:
+        {% for doc in documents %}
+            {{ doc.content }}
+        {% endfor %}
+
+        \nQuestion: {{question}}
+        \nAnswer:
+        """
+
+        document_store = InMemoryDocumentStore()
+        bm25_retriever = InMemoryBM25Retriever(document_store=document_store)
+
+        prompt_builder = PromptBuilder(template=prompt_template)
+        generator = HuggingFaceLocalGenerator(
+            model_name_or_path="google/flan-t5-small",
+            task="text2text-generation",
+            generation_kwargs={"max_new_tokens": 20, "temperature": 0.1, "do_sample": True, "num_return_sequences": 3},
+        )
+
+        answer_builder = AnswerBuilder()
+
+        document_store_2 = InMemoryDocumentStore()
+        bm25_retriever_2 = InMemoryBM25Retriever(document_store=document_store_2)
+
+        prompt_builder_2 = PromptBuilder(template=prompt_template)
+        generator_2 = HuggingFaceLocalGenerator(
+            model_name_or_path="google/flan-t5-small",
+            task="text2text-generation",
+            generation_kwargs={"max_new_tokens": 20, "temperature": 0.1, "do_sample": True, "num_return_sequences": 3},
+        )
+
+        answer_builder_2 = AnswerBuilder()
+
+        llm_ranker = LLMBlenderRanker(model="llm-blender/PairRM")
+
+        rag_pipeline = Pipeline()
+        rag_pipeline.add_component(instance=bm25_retriever, name="retriever")
+        rag_pipeline.add_component(instance=prompt_builder, name="prompt_builder")
+        rag_pipeline.add_component(
+            instance=generator,
+            name="llm",
+        )
+        rag_pipeline.add_component(instance=answer_builder, name="answer_builder")
+
+        rag_pipeline.add_component(instance=bm25_retriever_2, name="retriever_2")
+        rag_pipeline.add_component(instance=prompt_builder_2, name="prompt_builder_2")
+        rag_pipeline.add_component(
+            instance=generator_2,
+            name="llm_2",
+        )
+        rag_pipeline.add_component(instance=answer_builder_2, name="answer_builder_2")
+        rag_pipeline.add_component(instance=llm_ranker, name="llm_ranker")
+
+        # Connect the first pipeline
+        rag_pipeline.connect("retriever", "prompt_builder.documents")
+        rag_pipeline.connect("prompt_builder", "llm")
+        rag_pipeline.connect("llm.replies", "answer_builder.replies")
+        rag_pipeline.connect("retriever", "answer_builder.documents")
+        rag_pipeline.connect("answer_builder", "llm_ranker")
+
+        # Connect the second pipeline
+        rag_pipeline.connect("retriever_2", "prompt_builder_2.documents")
+        rag_pipeline.connect("prompt_builder_2", "llm_2")
+        rag_pipeline.connect("llm_2.replies", "answer_builder_2.replies")
+        rag_pipeline.connect("retriever_2", "answer_builder_2.documents")
+        rag_pipeline.connect("answer_builder_2", "llm_ranker")
+
+        # Populate the first document store
+        documents = [
+            Document(content="My name is Jean and I live in Paris."),
+            Document(content="My name is Mark and I live in Berlin."),
+            Document(content="My name is Giorgio and I live in Rome."),
+        ]
+        rag_pipeline.get_component("retriever").document_store.write_documents(documents)
+
+        # Populate the second document store
+        documents = [
+            Document(content="My name is Giorgio and I live in Paris."),
+            Document(content="My name is Mark and I live in Berlin."),
+            Document(content="My name is Jean and I live in Rome."),
+        ]
+        rag_pipeline.get_component("retriever_2").document_store.write_documents(documents)
+
+        question = "Who lives in Paris?"
+        outputs = rag_pipeline.run(
+            {
+                "retriever": {"query": question},
+                "prompt_builder": {"question": question},
+                "answer_builder": {"query": question},
+                "retriever_2": {"query": question},
+                "prompt_builder_2": {"question": question},
+                "answer_builder_2": {"query": question},
+            }
+        )
+
+        answers = outputs["llm_ranker"]["answers"]
+
+        assert answers == [
+            GeneratedAnswer(data="Jean", query="Who lives in Paris?", documents=[], meta={}),
+            GeneratedAnswer(data="Jean", query="Who lives in Paris?", documents=[], meta={}),
+            GeneratedAnswer(data="Jean", query="Who lives in Paris?", documents=[], meta={}),
+            GeneratedAnswer(data="Giorgio", query="Who lives in Paris?", documents=[], meta={}),
+            GeneratedAnswer(data="Giorgio", query="Who lives in Paris?", documents=[], meta={}),
+            GeneratedAnswer(data="Giorgio", query="Who lives in Paris?", documents=[], meta={}),
+        ]


### PR DESCRIPTION
### Proposed Changes:

- Adds a new component, `LLMBlenderRanker`. The component implements a LLM output ranking method with a pairwise reward model using the LLM Blender framework.
- Adds Haystack pipelines using the `LLMBlenderRanker` on the **MixInstruct** and **BillSum** datasets. The pipelines were run on 5 LLMs: [Mistral-7B-Instruct-v0.2](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2), [OpenChat-3.5-0106](https://huggingface.co/openchat/openchat-3.5-0106), [OpenHermes-2.5-Mistral-7B](https://huggingface.co/teknium/OpenHermes-2.5-Mistral-7B), [SOLAR-10.7B-Instruct-v1.0](https://huggingface.co/upstage/SOLAR-10.7B-Instruct-v1.0) and [Qwen1.5-7B-Chat](https://huggingface.co/Qwen/Qwen1.5-7B-Chat).

Some additional changes:
- `pyproject.toml` has been updated to include the dependencies for the LLM-Blender Framework.
- The test workflow has been added to run the tests for the new `LLMBlenderRanker` component.
- A `.gitignore` file has been added
