### PR TITLE
docs: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 <div align="center">
 
 [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/avnlp/rag-pipelines)
-[![code checks](https://github.com/avnlp/rag-pipelines/actions/workflows/code_checks.yml/badge.svg)](https://github.com/avnlp/rag-pipelines/actions/workflows/code_checks.yml)
-[![tests](https://github.com/avnlp/rag-pipelines/actions/workflows/tests.yml/badge.svg)](https://github.com/avnlp/rag-pipelines/actions/workflows/tests.yml)
-[![codecov](https://codecov.io/github/avnlp/rag-pipelines/graph/badge.svg?token=83MYFZ3UPA)](https://codecov.io/github/avnlp/rag-pipelines)
+[![CI](https://img.shields.io/github/actions/workflow/status/avnlp/rag-pipelines/ci.yml?branch=main&label=CI&logo=githubactions)](https://github.com/avnlp/rag-pipelines/actions/workflows/ci.yml)
+[![Ruff](https://img.shields.io/github/actions/workflow/status/avnlp/rag-pipelines/ci.yml?branch=main&label=Ruff&logo=ruff)](https://github.com/avnlp/rag-pipelines/actions/workflows/ci.yml)
+[![ty](https://img.shields.io/github/actions/workflow/status/avnlp/rag-pipelines/ci.yml?branch=main&label=ty&logo=python)](https://github.com/avnlp/rag-pipelines/actions/workflows/ci.yml)
+[![Bandit](https://img.shields.io/github/actions/workflow/status/avnlp/rag-pipelines/ci.yml?branch=main&label=Bandit&logo=owasp)](https://github.com/avnlp/rag-pipelines/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/avnlp/rag-pipelines/ci.yml?branch=main&label=Tests&logo=pytest)](https://github.com/avnlp/rag-pipelines/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/github/avnlp/rag-pipelines/graph/badge.svg?token=83MYFZ3UPA)](https://codecov.io/github/avnlp/rag-pipelines)
 [![License](https://img.shields.io/github/license/avnlp/rag-pipelines?color=green)](https://github.com/avnlp/rag-pipelines/blob/main/LICENSE)
 
 </div>


### PR DESCRIPTION
### Summary
 
Update README badges to replace stale individual workflow badges with consolidated CI badges. Also adds `ty` badge to reflect the mypy → ty migration.
 
### Changes
 
- **README.md**: Replaced stale `code_checks.yml` and `tests.yml` badges with consolidated `ci.yml` badges.
  - `CI` - consolidated workflow status
  - `Ruff` - linting/formatting
  - `ty` - type checking (replaces mypy)
  - `Bandit` - security scanning
  - `Tests` - test suite status

### Checklist

- [x] Code follows project style (`make lint-check`)
- [x] Type annotations pass (`make lint-typing`)
- [x] No typos (`make lint-typos`)
- [x] No new security issues (`make security-bandit`)
- [x] Dependency vulnerabilities checked (`make security-audit`)
- [x] Pre-commit hooks pass (`uv run pre-commit run --all-files`)
